### PR TITLE
fix(jupyter): ensure terminal is launched from home

### DIFF
--- a/jupyter/s6/s6-overlay/scripts/jupyterlab
+++ b/jupyter/s6/s6-overlay/scripts/jupyterlab
@@ -1,7 +1,8 @@
 #!/bin/sh -e
 
+cd "${HOME}"
+
 /opt/conda/bin/jupyter lab \
-  --config="${HOME}/.jupyter/jupyter_lab_config.py" \
   --notebook-dir="${HOME}" \
   --ip=0.0.0.0 \
   --no-browser \


### PR DESCRIPTION
Without this change, new terminals are opened in a strange directory.