### PR TITLE
feat(jupyter): add protected-packages file in image

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -60,6 +60,7 @@ RUN curl -sL "https://github.com/conda-forge/miniforge/releases/download/${MINIF
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && cat /tmp/requirements.txt >> /protected-packages.txt \
  && rm -f /tmp/requirements.txt \
  && jupyter lab --generate-config \
  && rm -rf ${HOME}/.cache/yarn \

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -61,7 +61,6 @@ RUN curl -sL "https://github.com/conda-forge/miniforge/releases/download/${MINIF
 COPY --chown=jovyan:users requirements.txt /tmp
 COPY --chown=jovyan:users requirements.txt /protected-packages.txt
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
- && cat /tmp/requirements.txt >> /protected-packages.txt \
  && rm -f /tmp/requirements.txt \
  && jupyter lab --generate-config \
  && rm -rf ${HOME}/.cache/yarn \

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -59,6 +59,7 @@ RUN curl -sL "https://github.com/conda-forge/miniforge/releases/download/${MINIF
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp
+COPY --chown=jovyan:users requirements.txt /protected-packages.txt
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && cat /tmp/requirements.txt >> /protected-packages.txt \
  && rm -f /tmp/requirements.txt \


### PR DESCRIPTION
This PR has the jupyter container image output the `requirements.txt` into `/protected-packages.txt`. This way, downstream dockerfiles that run `pip install` can use `--constraint /protected-packages.txt` to ensure the jupyter packages aren't accidentally downgraded and the build would fail if they are. The idea is that the `pytorch` and `tensorflow` dockerfiles will append their packages to that `protected-packages.txt` so we can ensure they aren't downgraded in the `-full` variant of those containers.