### PR TITLE
feat: update jupyter images to use protected packages

### DIFF
--- a/jupyter-go/Dockerfile
+++ b/jupyter-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.5.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.6.0
 
 USER root
 

--- a/jupyter-pytorch/cpu.Dockerfile
+++ b/jupyter-pytorch/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.5.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.6.0
 
 USER root
 
@@ -13,5 +13,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # install - requirements.txt
 COPY --chown=jovyan:users cpu-requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+RUN python3 -m pip install --constraint /protected-packages.txt -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && cat /tmp/requirements.txt >> /protected-packages.txt \
  && rm -f /tmp/requirements.txt

--- a/jupyter-pytorch/cuda.Dockerfile
+++ b/jupyter-pytorch/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.5.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.6.0
 
 USER root
 
@@ -18,5 +18,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # install - requirements.txt
 COPY --chown=jovyan:users cuda-requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+RUN python3 -m pip install --constraint /protected-packages.txt -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && cat /tmp/requirements.txt >> /protected-packages.txt \
  && rm -f /tmp/requirements.txt

--- a/jupyter-scipy/Dockerfile
+++ b/jupyter-scipy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.5.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.6.0
 
 USER root
 
@@ -13,6 +13,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+RUN python3 -m pip install --constraint /protected-packages.txt -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt \
  && jupyter lab build

--- a/jupyter-tensorflow/cpu.Dockerfile
+++ b/jupyter-tensorflow/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.5.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.6.0
 
 USER root
 
@@ -13,5 +13,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # install - requirements.txt
 COPY --chown=jovyan:users cpu-requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+RUN python3 -m pip install --constraint /protected-packages.txt -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && cat /tmp/requirements.txt >> /protected-packages.txt \
  && rm -f /tmp/requirements.txt

--- a/jupyter-tensorflow/cuda.Dockerfile
+++ b/jupyter-tensorflow/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.5.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter:2.6.0
 
 USER root
 
@@ -75,5 +75,6 @@ USER $NB_UID
 
 # install - requirements.txt
 COPY --chown=jovyan:users cuda-requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+RUN python3 -m pip install --constraint /protected-packages.txt -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && cat /tmp/requirements.txt >> /protected-packages.txt \
  && rm -f /tmp/requirements.txt


### PR DESCRIPTION
This updates the jupyter base image and makes it so downstream images can't accidentally downgrade jupyter. It also adds the pytorch and tensorflow packages to the protected packages file so that can be used in the `-full` versions of the images.