### PR TITLE
feat: full images with protected packages

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -141,6 +141,9 @@ jobs:
         load: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
       if: contains(matrix.project, 'cuda') == false
@@ -166,3 +169,6 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/jupyter-pytorch-full/cpu.Dockerfile
+++ b/jupyter-pytorch-full/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter-pytorch:2.3.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter-pytorch:2.4.0
 
 USER root
 
@@ -13,6 +13,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+RUN python3 -m pip install --constraint /protected-packages.txt -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt \
  && jupyter lab build

--- a/jupyter-pytorch-full/cuda.Dockerfile
+++ b/jupyter-pytorch-full/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter-pytorch-cuda:2.3.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter-pytorch-cuda:2.4.0
 
 USER root
 
@@ -13,6 +13,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+RUN python3 -m pip install --constraint /protected-packages.txt -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt \
  && jupyter lab build

--- a/jupyter-tensorflow-full/cpu.Dockerfile
+++ b/jupyter-tensorflow-full/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter-tensorflow:2.4.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter-tensorflow:2.5.0
 
 USER root
 
@@ -13,6 +13,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+RUN python3 -m pip install --constraint /protected-packages.txt -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt \
  && jupyter lab build

--- a/jupyter-tensorflow-full/cuda.Dockerfile
+++ b/jupyter-tensorflow-full/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter-tensorflow-cuda:2.4.0
+FROM ghcr.io/pluralsh/kubeflow-notebooks-jupyter-tensorflow-cuda:2.5.0
 
 USER root
 
@@ -13,6 +13,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+RUN python3 -m pip install --constraint /protected-packages.txt -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt \
  && jupyter lab build


### PR DESCRIPTION
This updates the `-full` images of pytorch and tensorflow so they respect the protected packages of the upstream images they use as a base. This should prevent a dependency of jupyterlab or pytorch/tensorflow respectively to get downgraded due to one of the packages.